### PR TITLE
Line equation bug fix

### DIFF
--- a/geomath/line.py
+++ b/geomath/line.py
@@ -23,9 +23,9 @@ class Line:
         self.Angulation = 0
         self.Angular = 0
         self.Linear = 0
-        self.A = 0
-        self.B = 0
-        self.C = 0
+        self.A = ""
+        self.B = ""
+        self.C = ""
         self.createdby = None
 
         if len(args)>1:
@@ -65,13 +65,13 @@ class Line:
         This function is for getting a line created by a line equation
         """
         self.createdby = "equation"
-        regex = re.compile(r'(\W?\d+)\S(\W\d+)\S(\W\d+)\=(\W?\d+)')
+        regex = re.compile(r'([\+\-]?\d*x)\s*([\+\-]\d*y)\s*([\+\-]\d*)\s*\=\s*([\+\-]?\d*)')
         values = regex.findall(equation)
         values = values[0]
-        self.A = values[0]
-        self.B = values[1]
+        self.A = "+1" if values[0] == 'x' or values[0] == '+x' else "-1" if values[0] == '-x' else values[0][:-1]
+        self.B = "+1" if values[1] == '+y' else "-1" if values[1] == '-y' else values[1][:-1]
         self.C = values[2]
-        self.Angular = (float(values[0]) / float(values[1]))
+        self.Angular = (float(self.A) / float(self.B))
         self.Angulation = degrees(atan(float(self.Angular)))
         self.PointOne = p.Point(float(self.C) / float(self.A),0)
         self.PointTwo = p.Point(0, float(self.C) / float(self.B))

--- a/test.py
+++ b/test.py
@@ -29,9 +29,9 @@ class LineTest(unittest.TestCase):
         assert(str(line) == "Line(Point(2, 2), Point(4, 4))")
 
     def test_instance_equation(self):
-        line = l.Line("-8x+6y-8=0")
+        line = l.Line("-x+y+8=0")
 
-        assert(str(line) == "A: -8 B: +6 C: -8")
+        assert(str(line) == "A: -1 B: +1 C: +8")
 
     def test_instance_one_point_and_slope(self):
         p1 = p.Point(4, 4.5)


### PR DESCRIPTION
This regex can match with "2x +2y +3 = 0" and not only to "2x+2y+3=0". And "-x+y+8=0" will be understood as "A: -1 B: +1 C: +8"
